### PR TITLE
feat: proxy-mode ingestion via cache-fix usage.jsonl (#2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ systemctl --user restart cache-fix-proxy
 claude-meter ingest --watch
 ```
 
-`claude-meter ingest` validates each row against the strict v:1 schema; old preload-format rows in any pre-existing files are skipped. Requires Node.js 18+.
+`claude-meter ingest` validates each row against the strict v:1 schema and **persists each valid row into `~/.claude/claude-meter.jsonl`** — the same local store that `analyze`, `share`, `status`, `history`, and `rates` already read from. No downstream command changes are needed; proxy-ingested rows are visible to all existing readers transparently. Old preload-format rows in any pre-existing source files are skipped (debug-logged when `CLAUDE_METER_DEBUG=1`). Requires Node.js 18+.
 
 > **Deprecation**: the `src/interceptor/preload.mjs` entry point still loads under Node-binary CC ≤ v2.1.112 but emits a deprecation warning on every invocation. The npm `./preload` export was removed in v0.4.0. The entry point itself is scheduled for removal in v1.0.0.
 

--- a/README.md
+++ b/README.md
@@ -33,22 +33,39 @@ One user sees one usage pattern. Many users see the full rate surface. claude-co
 npm install -g claude-code-meter
 ```
 
-Add the interceptor to your Claude Code wrapper:
+**Required collector:** since v0.4.0, claude-meter ingests data written by the [claude-code-cache-fix](https://github.com/cnighswonger/claude-code-cache-fix) proxy (>= 3.2.0). The proxy emits `MeterRowSchema` v:1 records to `~/.claude/usage.jsonl`; claude-meter reads from that file. The legacy `NODE_OPTIONS=--import` preload no longer works on Claude Code v2.1.113+ because the Bun binary ignores `NODE_OPTIONS`.
 
 ```bash
-# In your ~/bin/claude or wrapper script, add to NODE_OPTIONS:
-NODE_OPTIONS="--import $(npm root -g)/claude-code-meter/src/interceptor/preload.mjs"
+# 1. Install the proxy (once)
+npm install -g claude-code-cache-fix
+cache-fix-proxy install-service
+
+# 2. Enable the usage-log extension by editing
+#    ~/.config/cache-fix-proxy/extensions.json (or your installed proxy/extensions.json)
+#    and adding:
+#      "usage-log": { "enabled": true, "order": 650 }
+
+# 3. Restart the proxy and start ingesting
+systemctl --user restart cache-fix-proxy
+claude-meter ingest --watch
 ```
 
-If you're already using [claude-code-cache-fix](https://github.com/cnighswonger/claude-code-cache-fix), add the meter as a second `--import` — cache-fix first (modifies requests), meter second (reads responses).
+`claude-meter ingest` validates each row against the strict v:1 schema; old preload-format rows in any pre-existing files are skipped. Requires Node.js 18+.
 
-Requires Node.js 18+ and the Claude Code npm package (not the standalone binary).
+> **Deprecation**: the `src/interceptor/preload.mjs` entry point still loads under Node-binary CC ≤ v2.1.112 but emits a deprecation warning on every invocation. The npm `./preload` export was removed in v0.4.0. The entry point itself is scheduled for removal in v1.0.0.
 
 ## Usage
 
 ### Collect data
 
-Once installed, the interceptor runs automatically on every Claude Code session. Data is written to `~/.claude/claude-meter.jsonl`.
+Run `claude-meter ingest` (or `--watch` for continuous tailing) to pull rows from the proxy's `~/.claude/usage.jsonl`. The ingest command persists a byte offset to `~/.claude/.claude-meter-ingest-offset` so subsequent runs only process new rows. Ingest commands:
+
+```bash
+claude-meter ingest                    # read to current EOF, exit
+claude-meter ingest --watch            # tick every 1s until Ctrl-C
+claude-meter ingest --source <path>    # override source file path
+claude-meter ingest --reset-offset     # re-process from start (asks before deleting offset)
+```
 
 ### Analyze your cost model
 

--- a/bin/claude-meter.mjs
+++ b/bin/claude-meter.mjs
@@ -26,6 +26,11 @@ const { values, positionals } = parseArgs({
     share: { type: "boolean" },
     fit: { type: "boolean" },
     "log-file": { type: "string" },
+    // ingest subcommand
+    source: { type: "string" },
+    once: { type: "boolean" },
+    watch: { type: "boolean" },
+    "reset-offset": { type: "boolean" },
   },
 });
 
@@ -43,6 +48,7 @@ Commands:
   opt-out             Revoke data sharing consent (immediate, permanent until re-consented)
   share               Submit anonymized data to community dataset
   setup               Install interceptor and configure sharing
+  ingest              Ingest validated rows from cache-fix proxy's usage.jsonl
 
 Options:
   -s, --session <id>  Target a specific session
@@ -52,6 +58,10 @@ Options:
   -c, --community     Use community dataset for rates
   --share             Include share preview with analyze output
   --log-file <path>   Path to claude-meter.jsonl (default: ~/.claude/claude-meter.jsonl)
+  --source <path>     ingest: path to proxy usage.jsonl (default: ~/.claude/usage.jsonl)
+  --once              ingest: read to current EOF and exit (default behavior)
+  --watch             ingest: tick periodically until Ctrl-C
+  --reset-offset      ingest: delete offset file before reading (re-process from start)
   -y, --yes           Skip confirmation prompts
   -h, --help          Show this help
 `);
@@ -106,6 +116,17 @@ switch (command) {
   case "setup": {
     const { setupCommand } = await import("../src/cli/setup.mjs");
     await setupCommand(args);
+    break;
+  }
+  case "ingest": {
+    const { ingestCommand } = await import("../src/cli/ingest.mjs");
+    await ingestCommand({
+      source: values.source,
+      once: values.once,
+      watch: values.watch,
+      resetOffset: values["reset-offset"],
+      yes: values.yes,
+    });
     break;
   }
   default:

--- a/docs/code-reviews/pr-3-proxy-ingest-impl-rereview-2-2026-04-25.md
+++ b/docs/code-reviews/pr-3-proxy-ingest-impl-rereview-2-2026-04-25.md
@@ -1,0 +1,29 @@
+# Re-review 2: PR #3 proxy ingest implementation
+
+Date: 2026-04-25
+Reviewed: `src/cli/ingest.mjs`, `src/ingest/jsonl-tailer.mjs`, `test/ingest-cli.test.mjs`, `test/ingest-tailer.test.mjs`
+Branch: `pr-3`
+Head commit reviewed: `235f38a`
+Verdict: `APPROVE`
+
+## Verification
+
+- The tailer now separates validation from persistence. Validation failures still call `onSkip`, increment `skipped`, and advance the offset past the bad row because retrying malformed data is pointless ([src/ingest/jsonl-tailer.mjs](/home/manager/git_repos/claude-meter/src/ingest/jsonl-tailer.mjs:145)). Persistence failures from `onRow` now set `persistError`, emit a warning, and `break` before counting the failed row or any later rows in the batch, so order is preserved and rows 3+ are not advanced past when row 2 fails ([src/ingest/jsonl-tailer.mjs](/home/manager/git_repos/claude-meter/src/ingest/jsonl-tailer.mjs:164)).
+- Per-row byte tracking is implemented correctly. The tailer no longer advances by `Buffer.byteLength(completeBlock)`. Instead it accumulates `Buffer.byteLength(line, "utf8") + 1` only for rows that were successfully processed or intentionally skipped, then saves `offset + bytesConsumed` ([src/ingest/jsonl-tailer.mjs](/home/manager/git_repos/claude-meter/src/ingest/jsonl-tailer.mjs:135), [src/ingest/jsonl-tailer.mjs](/home/manager/git_repos/claude-meter/src/ingest/jsonl-tailer.mjs:175)).
+- `ingest.mjs` no longer swallows sink write failures. `appendFileSync()` now throws through `onRow`, which routes disk-full or permission errors into the tailer’s persistence-failure path instead of falsely counting the row as processed ([src/cli/ingest.mjs](/home/manager/git_repos/claude-meter/src/cli/ingest.mjs:58)).
+- The CLI surfaces the failure path correctly. Summary formatting includes `persistError` when present, and `ingest --once` sets exit code 1 if a persistence error occurred ([src/cli/ingest.mjs](/home/manager/git_repos/claude-meter/src/cli/ingest.mjs:15), [src/cli/ingest.mjs](/home/manager/git_repos/claude-meter/src/cli/ingest.mjs:80)).
+- Regression test #4 covers the lossy-path fix directly. It simulates a sink failure on row 2 of 3, asserts `processed === 1`, asserts `persistError` is populated, verifies the saved offset equals `Buffer.byteLength(JSON.stringify(row1) + "\n", "utf8")`, and confirms the retry tick processes rows 2 and 3 ([test/ingest-cli.test.mjs](/home/manager/git_repos/claude-meter/test/ingest-cli.test.mjs:93)).
+
+## Edge checks
+
+- Order preservation is correct: the `break` on persistence failure prevents any subsequent row in the batch from being processed or counted.
+- Empty trailing lines are handled correctly: `split("\n")` does produce a final empty string for a block ending in `\n`, but `if (!line) continue;` skips it before byte accounting, and the preceding row already accounted for that newline byte.
+- First-call semantics remain compatible with existing tests. Missing source still returns exactly `{ processed: 0, skipped: 0, offset: 0 }` without `persistError`, so the `deepEqual` assertions continue to pass ([src/ingest/jsonl-tailer.mjs](/home/manager/git_repos/claude-meter/src/ingest/jsonl-tailer.mjs:87), [test/ingest-tailer.test.mjs](/home/manager/git_repos/claude-meter/test/ingest-tailer.test.mjs:47), [test/ingest-cli.test.mjs](/home/manager/git_repos/claude-meter/test/ingest-cli.test.mjs:75)).
+- The newline math is correct for the implementation’s current assumption set. `+ 1` for `\n` is accurate on POSIX UTF-8 input, and I did not find any ingest-path tests or code handling `\r\n`; if Windows-style line endings are ever expected for this source, that would need separate coverage.
+
+## Tests
+
+- `node --test test/ingest-tailer.test.mjs test/ingest-cli.test.mjs`
+- Result: 14 passed, 0 failed
+
+Codex Review Agent

--- a/docs/code-reviews/pr-3-proxy-ingest-impl-rereview-2026-04-25.md
+++ b/docs/code-reviews/pr-3-proxy-ingest-impl-rereview-2026-04-25.md
@@ -1,0 +1,31 @@
+# Re-review: PR #3 proxy ingest implementation
+
+Date: 2026-04-25
+Reviewed: `src/cli/ingest.mjs`, `src/ingest/jsonl-tailer.mjs`, `test/ingest-cli.test.mjs`, `test/ingest-tailer.test.mjs`, `README.md`
+Branch: `pr-3`
+Head commit reviewed: `f47ee6a`
+Verdict: `REQUEST CHANGES`
+
+## Findings
+
+- Blocker: sink append failures currently become silent data loss. `ingestCommand()` now persists validated proxy rows by calling `appendFileSync(sink, JSON.stringify(row) + "\n")`, which is the right integration point, but the surrounding `try/catch` only logs a warning and then returns normally ([src/cli/ingest.mjs](/home/manager/git_repos/claude-meter/src/cli/ingest.mjs:53)). `JsonlTailer.tickOnce()` treats that callback as success, increments `processed`, and saves the advanced offset afterward ([src/ingest/jsonl-tailer.mjs](/home/manager/git_repos/claude-meter/src/ingest/jsonl-tailer.mjs:130), [src/ingest/jsonl-tailer.mjs](/home/manager/git_repos/claude-meter/src/ingest/jsonl-tailer.mjs:140)). In practice, any real sink write failure (disk full, permissions regression, transient I/O error) permanently drops rows: downstream readers never see them, but the source offset still advances past them. That is not just noisy logging; it breaks the durability guarantee this fix was meant to restore. The append error needs to fail the tick so the offset is not committed past unwritten rows.
+
+## Verified
+
+- The original persistence blocker is otherwise fixed correctly: valid proxy rows are now routed into the same sink file that `readAllRows()` consumers already use by default ([src/cli/ingest.mjs](/home/manager/git_repos/claude-meter/src/cli/ingest.mjs:27), [src/cli/ingest.mjs](/home/manager/git_repos/claude-meter/src/cli/ingest.mjs:50)).
+- No downstream reader changes were made in this PR. `git diff main..pr-3 -- src/log src/cli/analyze.mjs src/share` was empty, which matches the intended “persist into existing store” design.
+- The signal-handling race is improved as described: `cleanup` is async, performs a final `tickOnce()`, the signal handler awaits cleanup before exiting, and a `cleaning` guard prevents re-entry on double signal ([src/cli/ingest.mjs](/home/manager/git_repos/claude-meter/src/cli/ingest.mjs:97)).
+- The new `--sink` plumbing is present and defaults to `LOG_FILE`, which gives tests an isolated sink path without changing production defaults ([src/cli/ingest.mjs](/home/manager/git_repos/claude-meter/src/cli/ingest.mjs:29)).
+- The new CLI tests cover the claimed cases. The dedup test does exercise offset-based behavior by running `ingestCommand()` twice against the same source, appending only one new row between runs, asserting the second run reports `processed === 1`, and confirming the sink ends with exactly two rows ([test/ingest-cli.test.mjs](/home/manager/git_repos/claude-meter/test/ingest-cli.test.mjs:91)).
+- The README now accurately describes persistence into `~/.claude/claude-meter.jsonl` instead of overstating a migration that downstream commands could not actually see ([README.md](/home/manager/git_repos/claude-meter/README.md:53)).
+
+## Tests
+
+- `node --test test/ingest-tailer.test.mjs test/ingest-cli.test.mjs`
+- Result: 13 passed, 0 failed
+
+## Notes
+
+- I do not see the synchronous `appendFileSync` itself as an approval blocker for this CLI watch loop. It can stall the event loop under very high row throughput, but this command is already polling on a timer and writing one JSONL line per validated row; the more important correctness issue is to avoid acknowledging rows that were not durably appended.
+
+Codex Review Agent

--- a/docs/code-reviews/pr-3-proxy-ingest-impl-review-2026-04-25.md
+++ b/docs/code-reviews/pr-3-proxy-ingest-impl-review-2026-04-25.md
@@ -1,0 +1,27 @@
+# Review: PR #3 proxy ingest implementation
+
+Date: 2026-04-25
+Reviewed: `src/ingest/jsonl-tailer.mjs`, `src/cli/ingest.mjs`, `src/log/schema.mjs`, `src/log/reader.mjs`, `src/cli/analyze.mjs`, `src/share/payload-builder.mjs`, `src/constants.mjs`, `src/interceptor/preload.mjs`, `bin/claude-meter.mjs`, `package.json`, `README.md`, `docs/directives/proxy-ingest.md`, `test/ingest-tailer.test.mjs`
+Verdict: `REQUEST CHANGES`
+
+## What Is Correct
+
+- The tailer does enforce the wire contract at ingestion time. Each complete line is parsed with `JSON.parse()` and then validated through `MeterRowSchema.parse()`, so old preload-era rows and other v:1-incompatible shapes are rejected rather than silently accepted ([src/ingest/jsonl-tailer.mjs](/home/manager/git_repos/claude-meter/src/ingest/jsonl-tailer.mjs:124)).
+- The offset-handling logic is directionally correct. Complete lines advance the saved byte offset, trailing partial lines do not, and truncation resets to offset `0` with a stderr warning ([src/ingest/jsonl-tailer.mjs](/home/manager/git_repos/claude-meter/src/ingest/jsonl-tailer.mjs:95), [src/ingest/jsonl-tailer.mjs](/home/manager/git_repos/claude-meter/src/ingest/jsonl-tailer.mjs:113), [src/ingest/jsonl-tailer.mjs](/home/manager/git_repos/claude-meter/src/ingest/jsonl-tailer.mjs:141)).
+- The preload deprecation and packaging changes match the directive. The warning is emitted on import, the file still exists for direct path `--import`, `./preload` is removed from `exports`, and the version bump to `0.4.0` is present ([src/interceptor/preload.mjs](/home/manager/git_repos/claude-meter/src/interceptor/preload.mjs:25), [package.json](/home/manager/git_repos/claude-meter/package.json:3)).
+- The targeted tailer test file passes locally as requested: `node --test test/ingest-tailer.test.mjs` reported `10` passing tests and `0` failures.
+
+## Blockers
+
+- Codex review: this PR does not actually switch `claude-meter` to consume proxy-mode data for the product’s real workflows. `ingestCommand()` constructs the tailer with `onRow: () => {}` and never writes validated rows anywhere ([src/cli/ingest.mjs](/home/manager/git_repos/claude-meter/src/cli/ingest.mjs:38)). Meanwhile, the existing consumers still read only `LOG_FILE` / `~/.claude/claude-meter.jsonl` via `readAllRows()` ([src/log/reader.mjs](/home/manager/git_repos/claude-meter/src/log/reader.mjs:8)), and `analyze` still errors out telling the user to run the old interceptor if that file is empty ([src/cli/analyze.mjs](/home/manager/git_repos/claude-meter/src/cli/analyze.mjs:188)). `share` is in the same state because it also reads from `readAllRows()` with no proxy-log path integration ([src/share/payload-builder.mjs](/home/manager/git_repos/claude-meter/src/share/payload-builder.mjs:9)). As shipped, `claude-meter ingest --watch` only validates and counts rows; it does not make `analyze`, `share`, `status`, `history`, or `rates` operate on proxy data. That means the headline migration claim in the PR and README is not implemented yet.
+
+## Nits
+
+- The README currently states that “since v0.4.0, claude-meter ingests data written by the proxy” and presents `claude-meter ingest --watch` as the new collection flow ([README.md](/home/manager/git_repos/claude-meter/README.md:36), [README.md](/home/manager/git_repos/claude-meter/README.md:61)). Given the blocker above, that documentation overstates the current behavior and will send users into a dead end where ingestion appears to work but downstream commands still see no data.
+- `startWatch()` is implemented as timer-driven polling rather than filesystem watch events, which is fine, but the CLI signal handlers call `process.exit(0)` immediately after `cleanup()` ([src/cli/ingest.mjs](/home/manager/git_repos/claude-meter/src/cli/ingest.mjs:76)). If a tick is mid-flight when a signal lands, the process can terminate before the in-progress read/save completes. I would treat this as a follow-up robustness issue rather than the release blocker above.
+
+## Recommendation
+
+Revise before approval. The tailer itself is mostly in line with the directive and the new isolated tests pass, but the implementation stops at validation/counting. Until validated proxy rows are either persisted into the existing local store or all downstream readers are switched to consume the proxy JSONL directly, this PR does not complete the preload-to-proxy migration it claims to ship.
+
+Codex Review Agent

--- a/docs/directives/proxy-ingest.md
+++ b/docs/directives/proxy-ingest.md
@@ -1,0 +1,139 @@
+# Directive: Proxy-mode ingestion
+
+**Issue:** #2 (claude-meter), companion to `cnighswonger/claude-code-cache-fix#70` and `#81`
+**Branch:** `feature/proxy-ingest`
+**Stage:** directive + implementation (single PR)
+
+## Why
+
+CC v2.1.113+ ships as a Bun binary that ignores `NODE_OPTIONS=--import`. The `--import` preload mechanism that this collector has relied on since v0.1.0 is dead for every modern CC install. Cache-fix proxy v3.2.0 (PR #81 in that repo) now emits the **exact `MeterRowSchema` v:1** records this collector validates — straight to `~/.claude/usage.jsonl`. This PR closes the loop: switch claude-meter from in-process fetch interception to disk-based ingestion of the proxy's JSONL.
+
+Wire format is unchanged. Validation is unchanged. Share / upload protocol is unchanged. Only the **source** of rows changes.
+
+## Scope
+
+In scope:
+- New `src/ingest/jsonl-tailer.mjs` — reads `~/.claude/usage.jsonl` forward from a saved offset. Validates each line through the existing `MeterRowSchema` v:1. Skips invalid rows with debug log; never crashes the process.
+- New `src/cli/ingest.mjs` — CLI command implementing `claude-meter ingest [--source <path>] [--once] [--watch] [--reset-offset]`.
+- `bin/claude-meter.mjs` — add `ingest` subcommand to the dispatcher.
+- `src/constants.mjs` — add `PROXY_LOG_FILE` (default `~/.claude/usage.jsonl`) and `INGEST_OFFSET_FILE` (default `~/.claude/.claude-meter-ingest-offset`).
+- `src/interceptor/preload.mjs` — add a clear deprecation notice on import. Keep the file working for users who still have it pinned in `NODE_OPTIONS`, but warn on every load.
+- `package.json` — drop `./preload` from `exports` (so `import "@claude-meter/collector/preload"` no longer resolves), bump version `0.3.0 → 0.4.0`, declare `claude-code-cache-fix >= 3.2.0` as the supported source in README/SESSION_STATE notes (not as an npm peerDep — these are separate packages with separate install paths).
+- `README.md` — rewrite the integration section: install cache-fix proxy ≥3.2.0 → enable `usage-log` in `proxy/extensions.json` → run `claude-meter ingest`.
+- Tests for the tailer (offset persistence, valid/invalid row handling, watch mode tick).
+
+Out of scope:
+- Share/upload protocol changes.
+- Backfill of historical preload-written `~/.claude/claude-meter.jsonl` data. Already-collected data is what it is.
+- Removing `src/interceptor/` entirely. That happens in the next major (v1.0.0). For v0.4.0 we keep the files and just warn.
+
+## Wire contract
+
+This PR consumes the wire format pinned in `cnighswonger/claude-code-cache-fix#81`. The proxy emits `MeterRowSchema` v:1 records exactly as defined by `src/log/schema.mjs` here. The schema file is NOT modified by this PR — the ingest path validates against the same strict schema the writer has always validated against.
+
+A row is valid when `MeterRowSchema.parse(JSON.parse(line))` succeeds. Anything else is logged at debug level and skipped. Old 9-field rows from previous proxy `usage-log` versions WILL fail strict validation — they are skipped silently in production (debug log when `CLAUDE_METER_DEBUG=1`).
+
+## Implementation choice
+
+### Tailer
+
+```
+class JsonlTailer {
+  constructor({ source, offsetFile, onRow, onSkip, onError })
+  async tickOnce()    // read forward to current EOF, return { processed, skipped }
+  async startWatch(intervalMs = 1000)   // periodic tickOnce
+  async stopWatch()
+}
+```
+
+- Offset is the last fully-processed byte position in the source file.
+- Persist offset by writing `{ source, offset, updated_at }` to `offsetFile` after each successful tick.
+- If the source file's current size is LESS than the saved offset (file truncated/rotated), reset offset to 0 and log a warning.
+- Read forward from offset, split on `\n`, process complete lines. Carry an unfinished trailing fragment forward to the next tick (don't advance offset past it).
+- For each complete line: `MeterRowSchema.parse`. On success: optional callback `onRow(row)`. On failure: `onSkip({ line, error })`.
+
+### CLI subcommand
+
+`claude-meter ingest`:
+- Default mode: `--once` semantics. Read to current EOF, print summary `{ processed, skipped, offset }`, exit.
+- `--watch` mode: tick every 1s indefinitely. Print summary every minute (or per-tick if any rows processed/skipped). Ctrl-C exits cleanly with a final summary.
+- `--source <path>` overrides `PROXY_LOG_FILE` for one invocation.
+- `--reset-offset` deletes the offset file before reading. Useful for re-ingesting from scratch (e.g., after a development session). Prints a warning and confirmation prompt unless `--yes` is set.
+
+The ingest command does NOT submit to the share endpoint. It simply validates and counts. Share submission continues via `claude-meter share` / `claude-meter analyze --share` reading from the local validated rows. (For now, we treat the proxy JSONL as the source of validated rows directly; later we may merge into a unified local store.)
+
+### Preload deprecation
+
+`src/interceptor/preload.mjs` adds at the top:
+
+```js
+process.stderr.write(
+  "[claude-meter] DEPRECATED: the preload interceptor is unsupported on " +
+  "Claude Code v2.1.113+ (Bun binary ignores NODE_OPTIONS). " +
+  "Switch to: install claude-code-cache-fix >= 3.2.0, enable the usage-log " +
+  "extension, then run `claude-meter ingest --watch`. " +
+  "This entry point will be removed in claude-meter v1.0.0.\n"
+);
+```
+
+The fetch patch still installs (won't fire under Bun anyway, but stays correct under Node).
+
+### `package.json` exports
+
+Remove the `./preload` export. Users who run the preload directly via file path (`NODE_OPTIONS=--import /path/to/preload.mjs`) keep working — only the named `@claude-meter/collector/preload` import path goes away.
+
+```json
+"exports": {}
+```
+
+Or simply omit `exports` entirely. We don't expose a public ESM API beyond the CLI bin.
+
+## Test plan
+
+`test/ingest-tailer.test.mjs`:
+
+1. **Empty file**: tailer on a non-existent source → returns `{ processed: 0, skipped: 0 }`, doesn't error.
+2. **Single valid row**: write one MeterRowSchema-valid row → tickOnce processes it, offset advances to file size.
+3. **Multiple rows**: write 5 valid rows → tickOnce processes all 5, offset at EOF.
+4. **Trailing partial line**: write 2 rows + a half-written third → tickOnce processes 2, offset stops before the partial. Append the rest of row 3 → next tickOnce processes it.
+5. **Invalid row mid-stream**: write valid, invalid (missing required field), valid → tickOnce reports `processed: 2, skipped: 1`. Offset still at EOF.
+6. **Old proxy 9-field row**: write a v0 row with `peak_hour` and missing v field → skipped (strict validation).
+7. **Offset persistence**: tickOnce twice with new rows added in between → second tick only processes the new rows.
+8. **File truncation**: tickOnce, then truncate the source, then tickOnce → second tick resets offset to 0 and re-processes whatever's there.
+9. **Watch mode tick**: startWatch with 50ms interval, append a row, wait 100ms → row is processed.
+
+`test/cli-ingest.test.mjs` (lighter):
+
+1. `claude-meter ingest --once` on an empty source → exits 0 with summary.
+2. `claude-meter ingest --once --source <tmp>` with one valid row → exits 0, summary shows `processed: 1`.
+3. `--reset-offset --yes` deletes the offset file before reading.
+
+## Files modified / created
+
+| File | Change |
+|---|---|
+| `src/ingest/jsonl-tailer.mjs` | NEW |
+| `src/cli/ingest.mjs` | NEW |
+| `src/constants.mjs` | Add `PROXY_LOG_FILE`, `INGEST_OFFSET_FILE` |
+| `bin/claude-meter.mjs` | Add `ingest` case + help text |
+| `src/interceptor/preload.mjs` | Add deprecation stderr write at top |
+| `package.json` | Drop `./preload` from `exports`; bump `0.3.0 → 0.4.0` |
+| `README.md` | Rewrite integration section |
+| `test/ingest-tailer.test.mjs` | NEW |
+| `test/cli-ingest.test.mjs` | NEW |
+| `docs/directives/proxy-ingest.md` | THIS file |
+
+## Reviewer checklist
+
+- [ ] Tailer validates each row via `MeterRowSchema.parse` (strict v:1 only).
+- [ ] Invalid rows are skipped, not silently accepted. `onSkip` callback receives both line and error.
+- [ ] Offset is persisted after each tick and survives process restart.
+- [ ] File truncation/rotation resets offset to 0 with a warning.
+- [ ] Trailing partial line is preserved across ticks (not double-processed, not lost).
+- [ ] Preload deprecation warning fires on every load.
+- [ ] `package.json` `exports` no longer exposes `./preload`.
+- [ ] Version bumped to `0.4.0`.
+- [ ] README documents the new flow and pins `claude-code-cache-fix >= 3.2.0`.
+- [ ] All tests pass.
+
+— AI Team Lead

--- a/package.json
+++ b/package.json
@@ -1,13 +1,10 @@
 {
   "name": "claude-code-meter",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Community usage metrics collector for Claude Code — anonymized billing analysis and cost modeling",
   "type": "module",
   "bin": {
     "claude-meter": "bin/claude-meter.mjs"
-  },
-  "exports": {
-    "./preload": "./src/interceptor/preload.mjs"
   },
   "files": [
     "bin/",

--- a/src/cli/ingest.mjs
+++ b/src/cli/ingest.mjs
@@ -1,0 +1,85 @@
+// `claude-meter ingest` — read MeterRowSchema v:1 records emitted by the
+// cache-fix proxy's usage-log extension. See docs/directives/proxy-ingest.md.
+
+import { existsSync } from "node:fs";
+import { createInterface } from "node:readline";
+
+import { JsonlTailer } from "../ingest/jsonl-tailer.mjs";
+import { PROXY_LOG_FILE, INGEST_OFFSET_FILE } from "../constants.mjs";
+
+function fmtSummary({ processed, skipped, offset }) {
+  return `processed=${processed} skipped=${skipped} offset=${offset}`;
+}
+
+async function confirm(question) {
+  const rl = createInterface({ input: process.stdin, output: process.stdout });
+  const answer = await new Promise((resolve) => rl.question(`${question} [y/N] `, resolve));
+  rl.close();
+  return /^y(es)?$/i.test(answer.trim());
+}
+
+export async function ingestCommand(args = {}) {
+  const source = args.source || PROXY_LOG_FILE;
+  const offsetFile = args.offsetFile || INGEST_OFFSET_FILE;
+  const watch = !!args.watch;
+  const resetOffset = !!args.resetOffset;
+  const yes = !!args.yes;
+  const intervalMs = Number.isFinite(args.intervalMs) ? args.intervalMs : 1000;
+
+  if (!existsSync(source)) {
+    console.warn(`source not found: ${source}`);
+    console.warn("Hint: install claude-code-cache-fix >= 3.2.0 and enable the");
+    console.warn("usage-log extension in proxy/extensions.json:");
+    console.warn('  "usage-log": { "enabled": true, "order": 650 }');
+    process.exitCode = 0;
+    return { processed: 0, skipped: 0, offset: 0 };
+  }
+
+  const tailer = new JsonlTailer({
+    source,
+    offsetFile,
+    onRow: () => {},        // for now, validation count is enough; downstream consumers can override
+    onSkip: () => {},
+  });
+
+  if (resetOffset) {
+    if (!yes) {
+      const ok = await confirm(`Reset ingestion offset (will re-process all rows in ${source})?`);
+      if (!ok) {
+        console.log("Cancelled.");
+        return { processed: 0, skipped: 0, offset: 0 };
+      }
+    }
+    await tailer.resetOffset();
+    console.log(`Offset reset: ${offsetFile}`);
+  }
+
+  if (!watch) {
+    const result = await tailer.tickOnce();
+    console.log(`ingest --once: ${fmtSummary(result)}`);
+    return result;
+  }
+
+  console.log(`ingest --watch (interval=${intervalMs}ms, source=${source})`);
+  console.log("Press Ctrl-C to stop.");
+  let totalProcessed = 0;
+  let totalSkipped = 0;
+  const onTick = ({ processed, skipped, offset }) => {
+    if (processed || skipped) {
+      totalProcessed += processed;
+      totalSkipped += skipped;
+      console.log(`tick ${new Date().toISOString()}: ${fmtSummary({ processed, skipped, offset })}`);
+    }
+  };
+  const stop = tailer.startWatch(intervalMs, onTick);
+
+  return new Promise((resolve) => {
+    const cleanup = () => {
+      stop();
+      console.log(`final: processed=${totalProcessed} skipped=${totalSkipped}`);
+      resolve({ processed: totalProcessed, skipped: totalSkipped });
+    };
+    process.once("SIGINT", () => { cleanup(); process.exit(0); });
+    process.once("SIGTERM", () => { cleanup(); process.exit(0); });
+  });
+}

--- a/src/cli/ingest.mjs
+++ b/src/cli/ingest.mjs
@@ -1,11 +1,16 @@
 // `claude-meter ingest` — read MeterRowSchema v:1 records emitted by the
-// cache-fix proxy's usage-log extension. See docs/directives/proxy-ingest.md.
+// cache-fix proxy's usage-log extension and persist them into the local
+// ~/.claude/claude-meter.jsonl store so existing consumers (analyze, share,
+// status, history, rates) see proxy-ingested rows transparently.
+// See docs/directives/proxy-ingest.md.
 
-import { existsSync } from "node:fs";
+import { existsSync, appendFileSync } from "node:fs";
+import { mkdir } from "node:fs/promises";
 import { createInterface } from "node:readline";
+import { dirname } from "node:path";
 
 import { JsonlTailer } from "../ingest/jsonl-tailer.mjs";
-import { PROXY_LOG_FILE, INGEST_OFFSET_FILE } from "../constants.mjs";
+import { PROXY_LOG_FILE, INGEST_OFFSET_FILE, LOG_FILE } from "../constants.mjs";
 
 function fmtSummary({ processed, skipped, offset }) {
   return `processed=${processed} skipped=${skipped} offset=${offset}`;
@@ -21,6 +26,7 @@ async function confirm(question) {
 export async function ingestCommand(args = {}) {
   const source = args.source || PROXY_LOG_FILE;
   const offsetFile = args.offsetFile || INGEST_OFFSET_FILE;
+  const sink = args.sink || LOG_FILE;
   const watch = !!args.watch;
   const resetOffset = !!args.resetOffset;
   const yes = !!args.yes;
@@ -35,10 +41,25 @@ export async function ingestCommand(args = {}) {
     return { processed: 0, skipped: 0, offset: 0 };
   }
 
+  // Ensure sink directory exists once up front — appendFileSync per row is
+  // hot path; we don't want to mkdir on every call.
+  await mkdir(dirname(sink), { recursive: true });
+
+  // Persist each validated row into the local store so analyze / share /
+  // status / history / rates see proxy data transparently.
   const tailer = new JsonlTailer({
     source,
     offsetFile,
-    onRow: () => {},        // for now, validation count is enough; downstream consumers can override
+    onRow: (row) => {
+      try {
+        appendFileSync(sink, JSON.stringify(row) + "\n");
+      } catch (err) {
+        // Fail-open on write errors; the offset will still advance and the
+        // count of "processed" reflects validation success, but missing
+        // rows are surfaced via stderr so the operator can investigate.
+        process.stderr.write(`[claude-meter ingest] WARN: append to ${sink} failed: ${err?.message ?? err}\n`);
+      }
+    },
     onSkip: () => {},
   });
 
@@ -74,12 +95,22 @@ export async function ingestCommand(args = {}) {
   const stop = tailer.startWatch(intervalMs, onTick);
 
   return new Promise((resolve) => {
-    const cleanup = () => {
+    let cleaning = false;
+    const cleanup = async () => {
+      if (cleaning) return;
+      cleaning = true;
       stop();
+      // Run one final tick so any rows appended between the last interval
+      // and the signal don't get left for the next process.
+      try { await tailer.tickOnce(); } catch {}
       console.log(`final: processed=${totalProcessed} skipped=${totalSkipped}`);
       resolve({ processed: totalProcessed, skipped: totalSkipped });
     };
-    process.once("SIGINT", () => { cleanup(); process.exit(0); });
-    process.once("SIGTERM", () => { cleanup(); process.exit(0); });
+    const onSignal = async () => {
+      await cleanup();
+      process.exit(0);
+    };
+    process.once("SIGINT", onSignal);
+    process.once("SIGTERM", onSignal);
   });
 }

--- a/src/cli/ingest.mjs
+++ b/src/cli/ingest.mjs
@@ -12,8 +12,9 @@ import { dirname } from "node:path";
 import { JsonlTailer } from "../ingest/jsonl-tailer.mjs";
 import { PROXY_LOG_FILE, INGEST_OFFSET_FILE, LOG_FILE } from "../constants.mjs";
 
-function fmtSummary({ processed, skipped, offset }) {
-  return `processed=${processed} skipped=${skipped} offset=${offset}`;
+function fmtSummary({ processed, skipped, offset, persistError }) {
+  const base = `processed=${processed} skipped=${skipped} offset=${offset}`;
+  return persistError ? `${base} persistError=${persistError.message ?? persistError}` : base;
 }
 
 async function confirm(question) {
@@ -47,18 +48,18 @@ export async function ingestCommand(args = {}) {
 
   // Persist each validated row into the local store so analyze / share /
   // status / history / rates see proxy data transparently.
+  //
+  // appendFileSync errors are NOT swallowed — they propagate out of onRow,
+  // and the tailer treats that as a persistence failure (NOT a validation
+  // failure): it does NOT advance the offset past the failed row and
+  // returns `persistError` in the tick result. The next tick re-reads the
+  // same row, so the operator can fix the underlying cause (disk full,
+  // permission denied, etc.) without losing data permanently.
   const tailer = new JsonlTailer({
     source,
     offsetFile,
     onRow: (row) => {
-      try {
-        appendFileSync(sink, JSON.stringify(row) + "\n");
-      } catch (err) {
-        // Fail-open on write errors; the offset will still advance and the
-        // count of "processed" reflects validation success, but missing
-        // rows are surfaced via stderr so the operator can investigate.
-        process.stderr.write(`[claude-meter ingest] WARN: append to ${sink} failed: ${err?.message ?? err}\n`);
-      }
+      appendFileSync(sink, JSON.stringify(row) + "\n");
     },
     onSkip: () => {},
   });
@@ -78,6 +79,7 @@ export async function ingestCommand(args = {}) {
   if (!watch) {
     const result = await tailer.tickOnce();
     console.log(`ingest --once: ${fmtSummary(result)}`);
+    if (result.persistError) process.exitCode = 1;
     return result;
   }
 

--- a/src/constants.mjs
+++ b/src/constants.mjs
@@ -8,6 +8,13 @@ export const LOG_FILE = join(CLAUDE_DIR, "claude-meter.jsonl");
 export const CONFIG_FILE = join(CLAUDE_DIR, "claude-meter-config.json");
 export const MESSAGES_ENDPOINT = "/v1/messages";
 
+// Proxy-mode ingestion sources (see docs/directives/proxy-ingest.md).
+// Cache-fix proxy v3.2.0+ writes MeterRowSchema v:1 records to PROXY_LOG_FILE
+// when its `usage-log` extension is enabled. We tail forward from
+// INGEST_OFFSET_FILE to avoid re-processing rows across restarts.
+export const PROXY_LOG_FILE = join(CLAUDE_DIR, "usage.jsonl");
+export const INGEST_OFFSET_FILE = join(CLAUDE_DIR, ".claude-meter-ingest-offset");
+
 // Official API pricing ($/MTok)
 // Source: https://platform.claude.com/docs/en/docs/about-claude/pricing
 // Last verified: 2026-04-14

--- a/src/ingest/jsonl-tailer.mjs
+++ b/src/ingest/jsonl-tailer.mjs
@@ -121,36 +121,62 @@ export class JsonlTailer {
 
     // Split on \n. Anything after the last \n is incomplete and stays for next tick.
     const lastNewline = buffer.lastIndexOf("\n");
-    let completeBlock;
-    let advance;
     if (lastNewline < 0) {
       // No complete line in this segment — wait for more.
       return { processed: 0, skipped: 0, offset };
     }
-    completeBlock = buffer.slice(0, lastNewline + 1);
-    advance = Buffer.byteLength(completeBlock, "utf8");
+    const completeBlock = buffer.slice(0, lastNewline + 1);
 
     let processed = 0;
     let skipped = 0;
+    let persistError = null;
+    let bytesConsumed = 0;
+    // split("\n") on text ending in "\n" yields a trailing empty string. We
+    // skip empties without advancing (they represent zero source bytes; the
+    // preceding "\n" is already counted in the previous line's lineBytes).
     const lines = completeBlock.split("\n");
     for (const line of lines) {
       if (!line) continue;
+      // Each non-empty line consumes its bytes plus the "\n" that split removed.
+      const lineBytes = Buffer.byteLength(line, "utf8") + 1;
+
+      // First: validate the row. Validation failures advance past the row
+      // (the line is bad data; retrying won't help).
+      let validated;
       try {
         const parsed = JSON.parse(line);
-        const validated = MeterRowSchema.parse(parsed);
-        await this.onRow(validated);
-        processed++;
+        validated = MeterRowSchema.parse(parsed);
       } catch (err) {
         debug(`skip invalid row: ${err?.message ?? err}`);
         try { await this.onSkip({ line, error: err }); } catch {}
         skipped++;
+        bytesConsumed += lineBytes;
+        continue;
       }
+
+      // Then: persist via onRow. Persistence failures DO NOT advance offset.
+      // The next tick re-reads the same row, giving the operator a chance to
+      // fix the underlying cause (disk full, permission denied, etc.) without
+      // permanently dropping data. The error is surfaced loudly via stderr
+      // and returned in `persistError` so callers can react.
+      try {
+        await this.onRow(validated);
+      } catch (err) {
+        persistError = err;
+        warn(
+          `persistence failed; offset NOT advanced (will retry on next tick): ${err?.message ?? err}`,
+        );
+        break;
+      }
+
+      processed++;
+      bytesConsumed += lineBytes;
     }
 
-    const newOffset = offset + advance;
+    const newOffset = offset + bytesConsumed;
     await this.saveOffset(newOffset);
 
-    return { processed, skipped, offset: newOffset };
+    return { processed, skipped, offset: newOffset, persistError };
   }
 
   /**

--- a/src/ingest/jsonl-tailer.mjs
+++ b/src/ingest/jsonl-tailer.mjs
@@ -1,0 +1,189 @@
+// JsonlTailer — read forward from a saved offset, validate each row through
+// MeterRowSchema, persist offset across runs.
+//
+// Wire contract: cache-fix proxy v3.2.0+ writes MeterRowSchema v:1 records to
+// the source file. Older 9-field rows fail strict validation and are skipped
+// with a debug log.
+//
+// File rotation/truncation: if the source file's current size is LESS than
+// the saved offset, we reset offset to 0 and re-process from the start. A
+// warning is emitted on stderr.
+//
+// Trailing partial line: read forward but only advance offset past the last
+// complete `\n`. The unfinished trailing fragment is reprocessed on the next
+// tick.
+
+import {
+  readFile,
+  writeFile,
+  stat,
+  open,
+  unlink,
+  mkdir,
+} from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { dirname } from "node:path";
+
+import { MeterRowSchema } from "../log/schema.mjs";
+
+const DEBUG = process.env.CLAUDE_METER_DEBUG === "1";
+
+function debug(msg) {
+  if (DEBUG) process.stderr.write(`[claude-meter ingest] DEBUG: ${msg}\n`);
+}
+
+function warn(msg) {
+  process.stderr.write(`[claude-meter ingest] WARN: ${msg}\n`);
+}
+
+export class JsonlTailer {
+  /**
+   * @param {object} opts
+   * @param {string} opts.source        Path to the JSONL source file.
+   * @param {string} opts.offsetFile    Path to the offset persistence file.
+   * @param {(row: object) => void | Promise<void>} [opts.onRow]   Per-valid-row callback.
+   * @param {(skip: { line: string, error: Error }) => void | Promise<void>} [opts.onSkip] Per-invalid-row callback.
+   */
+  constructor({ source, offsetFile, onRow, onSkip } = {}) {
+    if (!source) throw new Error("JsonlTailer: `source` is required");
+    if (!offsetFile) throw new Error("JsonlTailer: `offsetFile` is required");
+    this.source = source;
+    this.offsetFile = offsetFile;
+    this.onRow = onRow || (() => {});
+    this.onSkip = onSkip || (() => {});
+    this._watching = false;
+    this._watchTimer = null;
+  }
+
+  async loadOffset() {
+    if (!existsSync(this.offsetFile)) return 0;
+    try {
+      const raw = await readFile(this.offsetFile, "utf8");
+      const parsed = JSON.parse(raw);
+      if (typeof parsed === "object" && parsed !== null && parsed.source === this.source && typeof parsed.offset === "number" && parsed.offset >= 0) {
+        return parsed.offset;
+      }
+      return 0;
+    } catch (err) {
+      debug(`offset file unreadable, starting from 0: ${err?.message ?? err}`);
+      return 0;
+    }
+  }
+
+  async saveOffset(offset) {
+    await mkdir(dirname(this.offsetFile), { recursive: true });
+    await writeFile(
+      this.offsetFile,
+      JSON.stringify({ source: this.source, offset, updated_at: new Date().toISOString() }),
+    );
+  }
+
+  async resetOffset() {
+    if (existsSync(this.offsetFile)) {
+      try { await unlink(this.offsetFile); } catch (err) {
+        debug(`failed to unlink offset file: ${err?.message ?? err}`);
+      }
+    }
+  }
+
+  /**
+   * Read forward from the saved offset to current EOF. Process complete lines.
+   * Returns { processed, skipped, offset }.
+   */
+  async tickOnce() {
+    if (!existsSync(this.source)) {
+      return { processed: 0, skipped: 0, offset: 0 };
+    }
+
+    const stats = await stat(this.source);
+    let offset = await this.loadOffset();
+
+    if (offset > stats.size) {
+      warn(`source file shrunk (offset=${offset} > size=${stats.size}); resetting offset to 0`);
+      offset = 0;
+    }
+
+    if (offset === stats.size) {
+      return { processed: 0, skipped: 0, offset };
+    }
+
+    // Read the segment from offset to EOF.
+    const fh = await open(this.source, "r");
+    let buffer;
+    try {
+      const len = stats.size - offset;
+      const arr = new Uint8Array(len);
+      await fh.read(arr, 0, len, offset);
+      buffer = Buffer.from(arr.buffer, arr.byteOffset, arr.byteLength).toString("utf8");
+    } finally {
+      await fh.close();
+    }
+
+    // Split on \n. Anything after the last \n is incomplete and stays for next tick.
+    const lastNewline = buffer.lastIndexOf("\n");
+    let completeBlock;
+    let advance;
+    if (lastNewline < 0) {
+      // No complete line in this segment — wait for more.
+      return { processed: 0, skipped: 0, offset };
+    }
+    completeBlock = buffer.slice(0, lastNewline + 1);
+    advance = Buffer.byteLength(completeBlock, "utf8");
+
+    let processed = 0;
+    let skipped = 0;
+    const lines = completeBlock.split("\n");
+    for (const line of lines) {
+      if (!line) continue;
+      try {
+        const parsed = JSON.parse(line);
+        const validated = MeterRowSchema.parse(parsed);
+        await this.onRow(validated);
+        processed++;
+      } catch (err) {
+        debug(`skip invalid row: ${err?.message ?? err}`);
+        try { await this.onSkip({ line, error: err }); } catch {}
+        skipped++;
+      }
+    }
+
+    const newOffset = offset + advance;
+    await this.saveOffset(newOffset);
+
+    return { processed, skipped, offset: newOffset };
+  }
+
+  /**
+   * Periodic ticks at `intervalMs` until `stopWatch()` is called. Returns a
+   * cancel function. Per-tick errors are logged but do not stop the watch.
+   */
+  startWatch(intervalMs = 1000, onTick) {
+    if (this._watching) throw new Error("already watching");
+    this._watching = true;
+    const tick = async () => {
+      if (!this._watching) return;
+      try {
+        const result = await this.tickOnce();
+        if (onTick) {
+          try { onTick(result); } catch {}
+        }
+      } catch (err) {
+        warn(`tick failed: ${err?.message ?? err}`);
+      } finally {
+        if (this._watching) {
+          this._watchTimer = setTimeout(tick, intervalMs);
+        }
+      }
+    };
+    tick();
+    return () => this.stopWatch();
+  }
+
+  stopWatch() {
+    this._watching = false;
+    if (this._watchTimer) {
+      clearTimeout(this._watchTimer);
+      this._watchTimer = null;
+    }
+  }
+}

--- a/src/interceptor/preload.mjs
+++ b/src/interceptor/preload.mjs
@@ -1,23 +1,37 @@
 /**
  * claude-meter interceptor preload.
  *
- * Load via: NODE_OPTIONS="--import @claude-meter/collector/preload"
- * or:       NODE_OPTIONS="--import /path/to/preload.mjs"
+ * DEPRECATED: as of claude-meter v0.4.0, this preload is unsupported on
+ * Claude Code v2.1.113+ (the Bun binary ignores NODE_OPTIONS). Use the
+ * proxy-mode ingest path instead:
+ *   1. Install claude-code-cache-fix >= 3.2.0
+ *   2. Enable the `usage-log` extension in proxy/extensions.json:
+ *        "usage-log": { "enabled": true, "order": 650 }
+ *   3. Run `claude-meter ingest --watch`
  *
- * This patches globalThis.fetch to capture usage metrics from Claude API
- * responses. It is strictly read-only — it never accesses request bodies
- * (prompts, code, files, tool schemas). Only response headers and the
- * usage object from the SSE stream are captured.
+ * This entry point will be removed in claude-meter v1.0.0. The npm
+ * `./preload` export was removed in v0.4.0; only direct file-path
+ * `--import` still resolves it.
  *
- * Captured data is written to ~/.claude/claude-meter.jsonl as strictly
- * numeric + fixed-enum fields. No freeform text.
+ * Historical behavior (still in place under Node-binary CC ≤ v2.1.112):
+ * patches globalThis.fetch to capture usage metrics from Claude API
+ * responses. Read-only — never accesses request bodies. Captured data is
+ * written to ~/.claude/claude-meter.jsonl.
  */
 
 import { installFetchPatch } from "./fetch-patch.mjs";
 import { checkIntegrity } from "./integrity.mjs";
 
+process.stderr.write(
+  "[claude-meter] DEPRECATED: the preload interceptor is unsupported on " +
+    "Claude Code v2.1.113+ (Bun binary ignores NODE_OPTIONS). " +
+    "Switch to: install claude-code-cache-fix >= 3.2.0, enable the " +
+    "usage-log extension, then run `claude-meter ingest --watch`. " +
+    "This entry point will be removed in claude-meter v1.0.0.\n",
+);
+
 // Integrity check — warn if source was modified post-install
 checkIntegrity(import.meta.url);
 
-// Install the fetch interceptor
+// Install the fetch interceptor (no-op under Bun where fetch isn't patched).
 installFetchPatch();

--- a/test/ingest-cli.test.mjs
+++ b/test/ingest-cli.test.mjs
@@ -93,6 +93,54 @@ test("CLI: ingest --once on missing source warns and exits cleanly", async () =>
   }
 });
 
+test("CLI: persistence failure does NOT advance offset (next tick retries)", async () => {
+  // Wire a tailer directly with an onRow that throws on the second row to
+  // prove the tailer doesn't permanently drop rows on sink write failures.
+  const { JsonlTailer } = await import("../src/ingest/jsonl-tailer.mjs");
+  const dir = await newTmp();
+  try {
+    const source = join(dir, "usage.jsonl");
+    const offsetFile = join(dir, ".offset");
+    const { writeFile, readFile } = await import("node:fs/promises");
+    await writeFile(
+      source,
+      JSON.stringify(validRow(1)) + "\n" + JSON.stringify(validRow(2)) + "\n" + JSON.stringify(validRow(3)) + "\n",
+    );
+
+    let callCount = 0;
+    const tailer = new JsonlTailer({
+      source,
+      offsetFile,
+      onRow: () => {
+        callCount++;
+        if (callCount === 2) throw new Error("simulated disk full");
+      },
+    });
+
+    const r1 = await tailer.tickOnce();
+    assert.equal(r1.processed, 1, "only the first row counted as processed before failure");
+    assert.ok(r1.persistError, "result must surface persistError");
+    assert.match(String(r1.persistError.message), /disk full/);
+
+    // Saved offset must NOT include row 2 or row 3 — only row 1's bytes.
+    const persisted = JSON.parse(await readFile(offsetFile, "utf8"));
+    const row1Bytes = Buffer.byteLength(JSON.stringify(validRow(1)) + "\n", "utf8");
+    assert.equal(persisted.offset, row1Bytes, "offset must stop at row 1's end, NOT advance through the failure");
+
+    // Now retry with an onRow that succeeds: rows 2 and 3 should both process.
+    const tailer2 = new JsonlTailer({
+      source,
+      offsetFile,
+      onRow: () => {},
+    });
+    const r2 = await tailer2.tickOnce();
+    assert.equal(r2.processed, 2, "after retry, previously-failed row and the next row both process");
+    assert.equal(r2.persistError, null);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
 test("CLI: ingest persistence dedups across runs via offset file", async () => {
   const origLog = console.log;
   console.log = () => {};

--- a/test/ingest-cli.test.mjs
+++ b/test/ingest-cli.test.mjs
@@ -1,0 +1,121 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, writeFile, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { ingestCommand } from "../src/cli/ingest.mjs";
+
+async function newTmp() {
+  return mkdtemp(join(tmpdir(), "claude-meter-ingest-cli-test-"));
+}
+
+function validRow(seq = 0) {
+  return {
+    v: 1,
+    ts: new Date(Date.UTC(2026, 3, 25, 10, 0, seq)).toISOString(),
+    sid: "abcdef01",
+    model: "claude-opus-4-7",
+    speed: "standard",
+    service_tier: "standard",
+    input_tokens: 100,
+    output_tokens: 200,
+    cache_creation_input_tokens: 50,
+    cache_read_input_tokens: 1000,
+    ephemeral_1h_input_tokens: 50,
+    ephemeral_5m_input_tokens: 0,
+    web_search_requests: 0,
+    q5h: 0.5,
+    q7d: 0.3,
+    q5h_reset: 1700000000,
+    q7d_reset: 1700100000,
+    qstatus: "allowed",
+    qoverage: "allowed",
+    qclaim: "five_hour",
+    qfallback_pct: 0.5,
+    cache_hit_rate: 0.8695652173913043,
+    q5h_delta: 0,
+    q7d_delta: 0,
+  };
+}
+
+test("CLI: ingest --once persists validated rows into the local sink (claude-meter.jsonl)", async () => {
+  // Suppress the "ingest --once: ..." console.log to keep test output clean.
+  const origLog = console.log;
+  console.log = () => {};
+  const dir = await newTmp();
+  try {
+    const source = join(dir, "usage.jsonl");
+    const offsetFile = join(dir, ".offset");
+    const sink = join(dir, "claude-meter.jsonl");
+
+    // Two valid rows in the proxy source.
+    await writeFile(
+      source,
+      JSON.stringify(validRow(1)) + "\n" + JSON.stringify(validRow(2)) + "\n",
+    );
+
+    const result = await ingestCommand({ source, offsetFile, sink, once: true });
+    assert.equal(result.processed, 2);
+    assert.equal(result.skipped, 0);
+
+    // Sink file must now contain the two rows verbatim, one per line, parseable.
+    const text = await readFile(sink, "utf8");
+    const lines = text.split("\n").filter(Boolean);
+    assert.equal(lines.length, 2, `sink should have 2 rows, got ${lines.length}`);
+    for (const line of lines) {
+      const row = JSON.parse(line);
+      assert.equal(row.v, 1);
+      assert.equal(row.sid, "abcdef01");
+    }
+  } finally {
+    console.log = origLog;
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("CLI: ingest --once on missing source warns and exits cleanly", async () => {
+  const origWarn = console.warn;
+  const origLog = console.log;
+  console.warn = () => {};
+  console.log = () => {};
+  const dir = await newTmp();
+  try {
+    const source = join(dir, "nonexistent.jsonl");
+    const offsetFile = join(dir, ".offset");
+    const sink = join(dir, "claude-meter.jsonl");
+    const result = await ingestCommand({ source, offsetFile, sink, once: true });
+    assert.deepEqual(result, { processed: 0, skipped: 0, offset: 0 });
+  } finally {
+    console.warn = origWarn;
+    console.log = origLog;
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("CLI: ingest persistence dedups across runs via offset file", async () => {
+  const origLog = console.log;
+  console.log = () => {};
+  const dir = await newTmp();
+  try {
+    const source = join(dir, "usage.jsonl");
+    const offsetFile = join(dir, ".offset");
+    const sink = join(dir, "claude-meter.jsonl");
+
+    await writeFile(source, JSON.stringify(validRow(1)) + "\n");
+    await ingestCommand({ source, offsetFile, sink, once: true });
+
+    // Append a second row.
+    const { appendFile } = await import("node:fs/promises");
+    await appendFile(source, JSON.stringify(validRow(2)) + "\n");
+
+    const result2 = await ingestCommand({ source, offsetFile, sink, once: true });
+    assert.equal(result2.processed, 1, "second run only processes the new row");
+
+    const lines = (await readFile(sink, "utf8")).split("\n").filter(Boolean);
+    assert.equal(lines.length, 2, "sink should have 2 rows total (no duplicates)");
+  } finally {
+    console.log = origLog;
+    await rm(dir, { recursive: true, force: true });
+  }
+});

--- a/test/ingest-tailer.test.mjs
+++ b/test/ingest-tailer.test.mjs
@@ -1,0 +1,267 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, writeFile, appendFile, readFile, rm, truncate } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { JsonlTailer } from "../src/ingest/jsonl-tailer.mjs";
+
+async function newTmp() {
+  return mkdtemp(join(tmpdir(), "claude-meter-ingest-test-"));
+}
+
+function validRow(seq = 0) {
+  // Bare-minimum fields satisfying MeterRowSchema v:1.
+  return {
+    v: 1,
+    ts: new Date(Date.UTC(2026, 3, 25, 10, 0, seq)).toISOString(),
+    sid: "abcdef01",
+    model: "claude-opus-4-7",
+    speed: "standard",
+    service_tier: "standard",
+    input_tokens: 100,
+    output_tokens: 200,
+    cache_creation_input_tokens: 50,
+    cache_read_input_tokens: 1000,
+    ephemeral_1h_input_tokens: 50,
+    ephemeral_5m_input_tokens: 0,
+    web_search_requests: 0,
+    q5h: 0.5,
+    q7d: 0.3,
+    q5h_reset: 1700000000,
+    q7d_reset: 1700100000,
+    qstatus: "allowed",
+    qoverage: "allowed",
+    qclaim: "five_hour",
+    qfallback_pct: 0.5,
+    cache_hit_rate: 0.8695652173913043,
+    q5h_delta: 0,
+    q7d_delta: 0,
+  };
+}
+
+function makePaths(dir) {
+  return {
+    source: join(dir, "usage.jsonl"),
+    offsetFile: join(dir, ".claude-meter-ingest-offset"),
+  };
+}
+
+test("1. tailer on missing source returns zeros without error", async () => {
+  const dir = await newTmp();
+  const { source, offsetFile } = makePaths(dir);
+  try {
+    const tailer = new JsonlTailer({ source, offsetFile });
+    const r = await tailer.tickOnce();
+    assert.deepEqual(r, { processed: 0, skipped: 0, offset: 0 });
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("2. single valid row → processed=1, offset advances", async () => {
+  const dir = await newTmp();
+  const { source, offsetFile } = makePaths(dir);
+  try {
+    await writeFile(source, JSON.stringify(validRow(1)) + "\n");
+    const tailer = new JsonlTailer({ source, offsetFile });
+    const r = await tailer.tickOnce();
+    assert.equal(r.processed, 1);
+    assert.equal(r.skipped, 0);
+    assert.ok(r.offset > 0);
+    // Offset persisted.
+    const persisted = JSON.parse(await readFile(offsetFile, "utf8"));
+    assert.equal(persisted.source, source);
+    assert.equal(persisted.offset, r.offset);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("3. multiple rows processed in one tick", async () => {
+  const dir = await newTmp();
+  const { source, offsetFile } = makePaths(dir);
+  try {
+    const lines = [validRow(1), validRow(2), validRow(3), validRow(4), validRow(5)]
+      .map((r) => JSON.stringify(r))
+      .join("\n") + "\n";
+    await writeFile(source, lines);
+    const tailer = new JsonlTailer({ source, offsetFile });
+    const r = await tailer.tickOnce();
+    assert.equal(r.processed, 5);
+    assert.equal(r.skipped, 0);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("4. trailing partial line preserved across ticks", async () => {
+  const dir = await newTmp();
+  const { source, offsetFile } = makePaths(dir);
+  try {
+    const r1Json = JSON.stringify(validRow(1));
+    const r2Json = JSON.stringify(validRow(2));
+    const r3Json = JSON.stringify(validRow(3));
+    // Two complete rows + half of a third (no trailing newline).
+    const partial = r3Json.slice(0, 30);
+    await writeFile(source, `${r1Json}\n${r2Json}\n${partial}`);
+
+    const tailer = new JsonlTailer({ source, offsetFile });
+    const r1 = await tailer.tickOnce();
+    assert.equal(r1.processed, 2, "should process the two complete rows only");
+    // Offset must NOT include the partial fragment.
+    const offsetAfter1 = JSON.parse(await readFile(offsetFile, "utf8")).offset;
+    const fsP = await import("node:fs/promises");
+    const sizeAfter1 = (await fsP.stat(source)).size;
+    assert.ok(offsetAfter1 < sizeAfter1, `offset (${offsetAfter1}) should be less than file size (${sizeAfter1})`);
+
+    // Append the rest of row 3.
+    await appendFile(source, r3Json.slice(30) + "\n");
+    const r2Tick = await tailer.tickOnce();
+    assert.equal(r2Tick.processed, 1, "should now process the completed third row");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("5. invalid row mid-stream is skipped, surrounding rows processed", async () => {
+  const dir = await newTmp();
+  const { source, offsetFile } = makePaths(dir);
+  try {
+    const invalidRow = { not: "a meter row" };
+    const lines = [
+      JSON.stringify(validRow(1)),
+      JSON.stringify(invalidRow),
+      JSON.stringify(validRow(2)),
+    ].join("\n") + "\n";
+    await writeFile(source, lines);
+
+    const skipped = [];
+    const tailer = new JsonlTailer({
+      source,
+      offsetFile,
+      onSkip: (s) => { skipped.push(s); },
+    });
+    const r = await tailer.tickOnce();
+    assert.equal(r.processed, 2);
+    assert.equal(r.skipped, 1);
+    assert.equal(skipped.length, 1);
+    assert.ok(skipped[0].error);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("6. old proxy 9-field row (no v field) is rejected", async () => {
+  const dir = await newTmp();
+  const { source, offsetFile } = makePaths(dir);
+  try {
+    // Old-shape proxy row from before MeterRowSchema alignment.
+    const oldRow = {
+      timestamp: "2026-04-25T10:00:00Z",
+      model: "claude-opus-4-7",
+      input_tokens: 100,
+      output_tokens: 50,
+      cache_read_input_tokens: 1000,
+      cache_creation_input_tokens: 50,
+      q5h_pct: 25,
+      q7d_pct: 5,
+      peak_hour: false,
+    };
+    await writeFile(source, JSON.stringify(oldRow) + "\n");
+    const tailer = new JsonlTailer({ source, offsetFile });
+    const r = await tailer.tickOnce();
+    assert.equal(r.processed, 0);
+    assert.equal(r.skipped, 1);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("7. offset persistence — second tick only processes new rows", async () => {
+  const dir = await newTmp();
+  const { source, offsetFile } = makePaths(dir);
+  try {
+    await writeFile(source, JSON.stringify(validRow(1)) + "\n");
+    const t1 = new JsonlTailer({ source, offsetFile });
+    const r1 = await t1.tickOnce();
+    assert.equal(r1.processed, 1);
+
+    await appendFile(source, JSON.stringify(validRow(2)) + "\n");
+    await appendFile(source, JSON.stringify(validRow(3)) + "\n");
+
+    const t2 = new JsonlTailer({ source, offsetFile });
+    const r2 = await t2.tickOnce();
+    assert.equal(r2.processed, 2, "expected only the two new rows");
+    assert.equal(r2.skipped, 0);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("8. file truncation resets offset to 0 and re-processes", async () => {
+  const dir = await newTmp();
+  const { source, offsetFile } = makePaths(dir);
+  try {
+    await writeFile(source, JSON.stringify(validRow(1)) + "\n" + JSON.stringify(validRow(2)) + "\n");
+    const t1 = new JsonlTailer({ source, offsetFile });
+    const r1 = await t1.tickOnce();
+    assert.equal(r1.processed, 2);
+
+    // Truncate to 0 and write fresh content.
+    await truncate(source, 0);
+    await writeFile(source, JSON.stringify(validRow(3)) + "\n");
+
+    const t2 = new JsonlTailer({ source, offsetFile });
+    const r2 = await t2.tickOnce();
+    assert.equal(r2.processed, 1, "after truncation, the new content is processed from offset 0");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("9. watch mode picks up appended rows", async () => {
+  const dir = await newTmp();
+  const { source, offsetFile } = makePaths(dir);
+  try {
+    await writeFile(source, "");
+    const events = [];
+    const tailer = new JsonlTailer({
+      source,
+      offsetFile,
+      onRow: (row) => { events.push(row.sid); },
+    });
+
+    let processed = 0;
+    tailer.startWatch(20, ({ processed: p }) => { processed += p; });
+    // Wait briefly for watch to be running.
+    await new Promise((r) => setTimeout(r, 30));
+    await appendFile(source, JSON.stringify(validRow(1)) + "\n");
+    // Let a couple ticks pass.
+    await new Promise((r) => setTimeout(r, 100));
+    tailer.stopWatch();
+    assert.ok(processed >= 1, `expected ≥1 processed via watch, got ${processed}`);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("10. resetOffset deletes the offset file", async () => {
+  const dir = await newTmp();
+  const { source, offsetFile } = makePaths(dir);
+  try {
+    await writeFile(source, JSON.stringify(validRow(1)) + "\n");
+    const tailer = new JsonlTailer({ source, offsetFile });
+    await tailer.tickOnce();
+    // Offset file should exist now.
+    const { existsSync } = await import("node:fs");
+    assert.equal(existsSync(offsetFile), true);
+    await tailer.resetOffset();
+    assert.equal(existsSync(offsetFile), false);
+    // Next tick re-processes from start.
+    const r = await tailer.tickOnce();
+    assert.equal(r.processed, 1);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

Closes the loop on the proxy-mode migration. cache-fix proxy v3.2.0 (just merged) writes `MeterRowSchema` v:1 records straight to `~/.claude/usage.jsonl` via its `usage-log` extension. This PR replaces claude-meter's broken NODE_OPTIONS preload with a disk-tailing ingest path that validates each row against the same strict schema.

Wire format unchanged. Validation unchanged. Share/upload protocol unchanged. Only the **source** of rows changes.

## What's in the PR

- `src/ingest/jsonl-tailer.mjs` — reads source forward from a saved byte offset, validates via `MeterRowSchema`, persists offset across runs, handles file truncation/rotation, preserves trailing partial lines across ticks.
- `src/cli/ingest.mjs` + bin wiring — `claude-meter ingest [--source] [--once] [--watch] [--reset-offset]`.
- `src/constants.mjs` — adds `PROXY_LOG_FILE` and `INGEST_OFFSET_FILE`.
- `src/interceptor/preload.mjs` — deprecation stderr write on import. Still works under Node-binary CC ≤ v2.1.112; scheduled for removal in v1.0.0.
- `package.json` — drops `./preload` export, bumps `0.3.0 → 0.4.0`.
- `README.md` — rewrites integration to: install cache-fix proxy ≥ 3.2.0 → enable `usage-log` → run `claude-meter ingest --watch`.
- `docs/directives/proxy-ingest.md` — full design + reviewer checklist.
- `test/ingest-tailer.test.mjs` — 10 test cases (per directive plan).

## Wire contract

The proxy emits exact `MeterRowSchema` v:1 records. The schema file in this repo is **NOT** modified by this PR — the ingest path validates against the unchanged strict schema. Anything that doesn't parse (including old 9-field preload-era proxy rows) is skipped with a debug log.

## Cross-repo release ordering

Per the cache-fix directive (#81 in that repo): cache-fix v3.2.0 ships first (merged). claude-meter v0.4.0 follows declaring `claude-code-cache-fix >= 3.2.0` as the supported producer. The two PRs are not independently shippable.

## Test plan

- [x] `test/ingest-tailer.test.mjs` — 10/10 passing
- [ ] Manual: enable `usage-log` on local proxy, run `claude-meter ingest --watch`, confirm rows count up
- [ ] Manual: `--reset-offset --yes` re-ingests from start

Note: `test/server-security.test.mjs` has a pre-existing hang on Node 24 unrelated to this change. The new tailer tests pass cleanly in isolation.

## Reviewer checklist

(Full checklist in `docs/directives/proxy-ingest.md`. Highlights:)
- Tailer validates each row via `MeterRowSchema.parse` (strict v:1 only)
- Invalid rows are skipped, not silently accepted
- Offset persists across runs
- Truncation/rotation resets offset to 0 with warning
- Trailing partial line preserved across ticks
- Preload deprecation warning fires on every load
- `package.json` `exports` no longer exposes `./preload`
- Version bumped to `0.4.0`
- README pins `claude-code-cache-fix >= 3.2.0` as required producer

— AI Team Lead