### PR TITLE
fix: /api/v1/stats type-aware aggregation across share + analysis rows

### DIFF
--- a/server/index.mjs
+++ b/server/index.mjs
@@ -22,6 +22,8 @@ import { randomBytes, createHash } from "node:crypto";
 import { z } from "zod";
 import { fileURLToPath } from "node:url";
 
+import { computeStatsAggregate } from "./stats-aggregate.mjs";
+
 const __dirname = fileURLToPath(new URL(".", import.meta.url));
 const PUBLIC_DIR = join(__dirname, "..", "public");
 
@@ -309,22 +311,11 @@ const server = createServer(async (req, res) => {
       return;
     }
 
-    // GET /api/v1/stats
+    // GET /api/v1/stats — see computeStatsAggregate below for the aggregation
+    // contract (handles both SharePayloadSchema and analysis submissions).
     if (method === "GET" && path === "/api/v1/stats") {
       const rows = readAllSubmissions();
-      const models = new Map();
-      let totalTurns = 0;
-      for (const r of rows) {
-        models.set(r.model, (models.get(r.model) || 0) + 1);
-        totalTurns += r.turn_count || 0;
-      }
-      return json(res, 200, {
-        total_submissions: rows.length,
-        total_turns: totalTurns,
-        models: Object.fromEntries(models),
-        earliest: rows.length > 0 ? rows[0].date : null,
-        latest: rows.length > 0 ? rows[rows.length - 1].date : null,
-      });
+      return json(res, 200, computeStatsAggregate(rows));
     }
 
     // GET /api/v1/schema

--- a/server/stats-aggregate.mjs
+++ b/server/stats-aggregate.mjs
@@ -1,0 +1,73 @@
+/**
+ * Aggregate /api/v1/stats response across both submission types:
+ *   - SharePayloadSchema rows (per-session aggregate): top-level `model`,
+ *     `turn_count`, `date`. One row = one session of one model.
+ *   - Analysis rows (`type: "analysis"`): nested `model_splits` (object keyed
+ *     by model name with per-model `n_calls`), `n_calls`, `n_sessions`,
+ *     `generated_at`.
+ *
+ * Pure function — kept in its own module so unit tests don't pull in the
+ * full server (which auto-starts an HTTP listener on import).
+ *
+ * Returns:
+ *   {
+ *     total_submissions, submissions_by_type: { share, analysis },
+ *     total_calls, total_turns (back-compat alias for total_calls),
+ *     total_sessions, models (CALL counts per model name),
+ *     earliest, latest
+ *   }
+ *
+ * Prior to 2026-04-26 the endpoint assumed SharePayloadSchema shape and
+ * returned `total_turns: 0` and `models: { undefined: N }` for analysis
+ * submissions. This function detects the shape per row and aggregates
+ * correctly across mixed-type datasets.
+ */
+export function computeStatsAggregate(rows) {
+  const models = new Map();
+  let totalCalls = 0;
+  let totalSessions = 0;
+  let shareSubmissions = 0;
+  let analysisSubmissions = 0;
+  const dates = [];
+
+  for (const r of rows) {
+    if (r && r.type === "analysis") {
+      analysisSubmissions++;
+      totalCalls += Number.isFinite(r.n_calls) ? r.n_calls : 0;
+      totalSessions += Number.isFinite(r.n_sessions) ? r.n_sessions : 0;
+      if (r.model_splits && typeof r.model_splits === "object") {
+        for (const [modelName, modelData] of Object.entries(r.model_splits)) {
+          const calls = (modelData && typeof modelData === "object" && Number.isFinite(modelData.n_calls))
+            ? modelData.n_calls
+            : 0;
+          models.set(modelName, (models.get(modelName) || 0) + calls);
+        }
+      }
+      if (r.generated_at) dates.push(r.generated_at);
+      else if (r.data_range && r.data_range.end) dates.push(r.data_range.end);
+    } else if (r) {
+      // Default: treat as SharePayloadSchema (legacy rows have no `type`).
+      shareSubmissions++;
+      const turns = Number.isFinite(r.turn_count) ? r.turn_count : 0;
+      totalCalls += turns;
+      totalSessions += 1; // share submission = one session
+      if (r.model) {
+        models.set(r.model, (models.get(r.model) || 0) + turns);
+      }
+      if (r.date) dates.push(r.date);
+    }
+  }
+
+  dates.sort();
+
+  return {
+    total_submissions: rows.length,
+    submissions_by_type: { share: shareSubmissions, analysis: analysisSubmissions },
+    total_calls: totalCalls,
+    total_turns: totalCalls, // back-compat alias
+    total_sessions: totalSessions,
+    models: Object.fromEntries(models), // CALL counts per model, not submission counts
+    earliest: dates.length > 0 ? dates[0] : null,
+    latest: dates.length > 0 ? dates[dates.length - 1] : null,
+  };
+}

--- a/test/stats-aggregate.test.mjs
+++ b/test/stats-aggregate.test.mjs
@@ -1,0 +1,185 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { computeStatsAggregate } from "../server/stats-aggregate.mjs";
+
+// --- SharePayloadSchema rows (legacy / per-session) ---
+
+test("share row aggregation: model + turn_count → models map by call count", () => {
+  const rows = [
+    { v: 1, date: "2026-04-20", model: "claude-opus-4-7", turn_count: 50 },
+    { v: 1, date: "2026-04-21", model: "claude-opus-4-7", turn_count: 30 },
+    { v: 1, date: "2026-04-22", model: "claude-haiku-4-5", turn_count: 100 },
+  ];
+  const out = computeStatsAggregate(rows);
+  assert.equal(out.total_submissions, 3);
+  assert.deepEqual(out.submissions_by_type, { share: 3, analysis: 0 });
+  assert.equal(out.total_calls, 180);
+  assert.equal(out.total_turns, 180); // back-compat alias
+  assert.equal(out.total_sessions, 3); // each share row = 1 session
+  assert.deepEqual(out.models, { "claude-opus-4-7": 80, "claude-haiku-4-5": 100 });
+  assert.equal(out.earliest, "2026-04-20");
+  assert.equal(out.latest, "2026-04-22");
+});
+
+// --- Analysis rows (current daily push) ---
+
+test("analysis row aggregation: model_splits + n_calls + n_sessions", () => {
+  const rows = [
+    {
+      type: "analysis",
+      v: 1,
+      generated_at: "2026-04-25T06:37:02.680Z",
+      n_calls: 24667,
+      n_sessions: 119,
+      model_splits: {
+        "claude-opus-4-6": { n_calls: 20064, avg_q5h_per_turn: 0.003823 },
+        "claude-haiku-4-5": { n_calls: 2328, avg_q5h_per_turn: 0.001065 },
+        "claude-sonnet-4-6": { n_calls: 21, avg_q5h_per_turn: 0.001905 },
+        "claude-opus-4-7": { n_calls: 2254, avg_q5h_per_turn: 0.004215 },
+      },
+    },
+  ];
+  const out = computeStatsAggregate(rows);
+  assert.equal(out.total_submissions, 1);
+  assert.deepEqual(out.submissions_by_type, { share: 0, analysis: 1 });
+  assert.equal(out.total_calls, 24667);
+  assert.equal(out.total_turns, 24667);
+  assert.equal(out.total_sessions, 119);
+  assert.deepEqual(out.models, {
+    "claude-opus-4-6": 20064,
+    "claude-haiku-4-5": 2328,
+    "claude-sonnet-4-6": 21,
+    "claude-opus-4-7": 2254,
+  });
+  assert.equal(out.earliest, "2026-04-25T06:37:02.680Z");
+  assert.equal(out.latest, "2026-04-25T06:37:02.680Z");
+});
+
+// --- Mixed dataset ---
+
+test("mixed dataset: share + analysis aggregate together by call count", () => {
+  const rows = [
+    // Share row: 50 calls of opus-4-7.
+    { v: 1, date: "2026-04-20", model: "claude-opus-4-7", turn_count: 50 },
+    // Analysis: 100 opus-4-7 + 200 haiku-4-5.
+    {
+      type: "analysis",
+      v: 1,
+      generated_at: "2026-04-25T06:37:02.680Z",
+      n_calls: 300,
+      n_sessions: 5,
+      model_splits: {
+        "claude-opus-4-7": { n_calls: 100 },
+        "claude-haiku-4-5": { n_calls: 200 },
+      },
+    },
+  ];
+  const out = computeStatsAggregate(rows);
+  assert.equal(out.total_submissions, 2);
+  assert.deepEqual(out.submissions_by_type, { share: 1, analysis: 1 });
+  assert.equal(out.total_calls, 350); // 50 share + 300 analysis
+  assert.equal(out.total_sessions, 6); // 1 share + 5 analysis sessions
+  assert.deepEqual(out.models, {
+    "claude-opus-4-7": 150, // 50 (share) + 100 (analysis)
+    "claude-haiku-4-5": 200,
+  });
+  // Dates: share has date "2026-04-20", analysis has generated_at "2026-04-25...".
+  assert.equal(out.earliest, "2026-04-20");
+  assert.equal(out.latest, "2026-04-25T06:37:02.680Z");
+});
+
+// --- Regression: pre-fix bug shape ---
+
+test("regression: analysis row no longer produces models: { undefined: 1 }", () => {
+  // This is the EXACT submission shape that was on the live server pre-fix.
+  // Before: stats returned { total_turns: 0, models: { undefined: 1 } }.
+  // After: stats returns total_calls=24667 and properly named model keys.
+  const rows = [{
+    type: "analysis",
+    v: 1,
+    generated_at: "2026-04-25T06:37:02.680Z",
+    install_id: "39b82237b25bbfc7",
+    data_range: { start: "2026-04-04T19:05:18.878Z", end: "2026-04-23T11:54:42.136Z" },
+    plan_tier: "unknown",
+    n_sessions: 119,
+    n_calls: 24667,
+    model_splits: {
+      "claude-opus-4-6": { n_calls: 20064 },
+      "claude-haiku-4-5": { n_calls: 2328 },
+    },
+  }];
+  const out = computeStatsAggregate(rows);
+  // The "undefined" key from the pre-fix bug must NOT be present.
+  assert.equal("undefined" in out.models, false, "pre-fix bug regression: 'undefined' must not be a model key");
+  assert.ok(out.total_turns > 0, "total_turns must reflect actual call count");
+  assert.equal(out.total_calls, 24667);
+});
+
+// --- Edge cases ---
+
+test("empty rows array → zero counts, null dates", () => {
+  const out = computeStatsAggregate([]);
+  assert.equal(out.total_submissions, 0);
+  assert.deepEqual(out.submissions_by_type, { share: 0, analysis: 0 });
+  assert.equal(out.total_calls, 0);
+  assert.equal(out.total_sessions, 0);
+  assert.deepEqual(out.models, {});
+  assert.equal(out.earliest, null);
+  assert.equal(out.latest, null);
+});
+
+test("malformed analysis row missing model_splits → zero models contribution", () => {
+  const rows = [{
+    type: "analysis",
+    v: 1,
+    generated_at: "2026-04-25T06:37:02.680Z",
+    n_calls: 100,
+    n_sessions: 5,
+    // model_splits intentionally absent
+  }];
+  const out = computeStatsAggregate(rows);
+  assert.equal(out.total_calls, 100);
+  assert.deepEqual(out.models, {});
+});
+
+test("share row missing model field → no model bucket created", () => {
+  const rows = [{ v: 1, date: "2026-04-20", turn_count: 10 }];
+  const out = computeStatsAggregate(rows);
+  assert.equal(out.total_calls, 10);
+  assert.deepEqual(out.models, {});
+});
+
+test("analysis row uses data_range.end as date fallback if no generated_at", () => {
+  const rows = [{
+    type: "analysis",
+    v: 1,
+    n_calls: 10,
+    n_sessions: 1,
+    data_range: { start: "2026-04-01", end: "2026-04-10" },
+  }];
+  const out = computeStatsAggregate(rows);
+  assert.equal(out.earliest, "2026-04-10");
+});
+
+test("non-finite numeric fields are coerced to 0 (no NaN propagation)", () => {
+  const rows = [
+    { v: 1, date: "2026-04-20", model: "x", turn_count: "fifty" }, // non-numeric
+    { type: "analysis", v: 1, n_calls: NaN, n_sessions: undefined, model_splits: {} },
+  ];
+  const out = computeStatsAggregate(rows);
+  assert.equal(Number.isFinite(out.total_calls), true);
+  assert.equal(out.total_calls, 0);
+  assert.equal(out.total_sessions, 1); // 1 share + 0 analysis
+});
+
+test("null and non-object rows are tolerated", () => {
+  // Defensive: should not throw on pathological inputs even though they
+  // shouldn't appear in production (data file is guarded by schema validation
+  // at write time).
+  const rows = [null, undefined];
+  // null is filtered by `r &&` checks; undefined likewise.
+  const out = computeStatsAggregate(rows);
+  assert.equal(out.total_submissions, 2); // rows.length still 2
+  assert.equal(out.total_calls, 0);
+});


### PR DESCRIPTION
## The bug

`/api/v1/stats` returned `{"total_submissions":1,"total_turns":0,"models":{"undefined":1}}` even though the live submission has 24,667 calls across 4 properly-named models. The dashboard's client-side computation (reading `/api/v1/dataset` directly) shows the correct numbers, but the public API endpoint was misleading.

Root cause at `server/index.mjs` (pre-fix lines 312-328): the endpoint reads `r.model` and `r.turn_count` from each row, which assumes `SharePayloadSchema` shape. Our only submission is the daily `analyze --share` output, which is `AnalysisPayloadSchema` — model breakdown lives under `model_splits` and call counts under `n_calls`.

## The fix

Detect submission shape per row and aggregate accordingly:

- **Share rows** (no `type` field, has `model` + `turn_count`) → contribute `turn_count` to `total_calls` and to the `model` bucket.
- **Analysis rows** (`type: "analysis"`) → contribute `n_calls` to `total_calls` AND walk `model_splits`, contributing each per-model `n_calls` to its own bucket.

Response shape (additions in **bold**):
- `total_submissions` (unchanged)
- **`submissions_by_type: { share, analysis }`** (new — transparency for mixed-type datasets)
- **`total_calls`** (new — same as `total_turns` but more accurate name)
- `total_turns` (back-compat alias for `total_calls`)
- **`total_sessions`** (new — sum of `n_sessions` for analysis rows + 1 per share row)
- `models` (now keyed by model name → **CALL counts**, not submission counts)
- `earliest`, `latest` (now correctly handles both `date` and `generated_at`)

## Refactor: extract pure function

Moved aggregation logic to `server/stats-aggregate.mjs` so unit tests can import it without pulling in the full server (which auto-starts an HTTP listener on import — same hang we observed previously when trying to run `test/server-security.test.mjs`).

## Tests (10 cases)

- Share row aggregation by call count
- Analysis row aggregation via `model_splits`
- Mixed dataset (share + analysis combined)
- **Regression**: live submission shape no longer produces `models: { undefined }`
- Empty input → zero counts, null dates
- Malformed analysis (missing `model_splits`)
- Share row missing `model`
- Analysis date fallback (`data_range.end` if no `generated_at`)
- NaN / non-finite coercion to 0
- Null / undefined rows tolerated

All pass: `node --test test/stats-aggregate.test.mjs` → 10/10.

## Live verification once merged + deployed

```bash
curl -sf https://meter.veritassuperaitsolutions.com/api/v1/stats | jq
```

Expected (today's data): `total_calls: 24667`, `total_sessions: 119`, `models: { "claude-opus-4-6": 20064, "claude-haiku-4-5": 2328, "claude-sonnet-4-6": 21, "claude-opus-4-7": 2254 }`.

— AI Team Lead