### PR TITLE
feat: migrate to meter.vsits.co (corporate domain rebrand)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # claude-code-meter
 
-[![npm](https://img.shields.io/npm/v/claude-code-meter?color=blue)](https://www.npmjs.com/package/claude-code-meter) [![Node.js](https://img.shields.io/badge/Node.js-18%2B-green)](https://nodejs.org/) [![License: MIT](https://img.shields.io/badge/License-MIT-yellow)](https://opensource.org/licenses/MIT) [![Dashboard](https://img.shields.io/badge/Dashboard-Live-brightgreen)](https://meter.veritassuperaitsolutions.com)
+[![npm](https://img.shields.io/npm/v/claude-code-meter?color=blue)](https://www.npmjs.com/package/claude-code-meter) [![Node.js](https://img.shields.io/badge/Node.js-18%2B-green)](https://nodejs.org/) [![License: MIT](https://img.shields.io/badge/License-MIT-yellow)](https://opensource.org/licenses/MIT) [![Dashboard](https://img.shields.io/badge/Dashboard-Live-brightgreen)](https://meter.vsits.co)
 
 Community usage metrics collector for Claude Code. Captures anonymized billing data from API responses and provides session-level cost modeling through statistical analysis.
 
-**Live dashboard:** [meter.veritassuperaitsolutions.com](https://meter.veritassuperaitsolutions.com)
+**Live dashboard:** [meter.vsits.co](https://meter.vsits.co)
 
 ## What it does
 
@@ -88,7 +88,7 @@ claude-meter analyze --share
 # Shows the exact JSON before sending. You confirm before anything is transmitted.
 ```
 
-Data goes to [meter.veritassuperaitsolutions.com](https://meter.veritassuperaitsolutions.com) and is visible on the community dashboard.
+Data goes to [meter.vsits.co](https://meter.vsits.co) and is visible on the community dashboard.
 
 ### View your metrics
 
@@ -156,7 +156,7 @@ The interceptor uses `response.clone()`, not `TransformStream`. This is critical
 
 ## Community server
 
-The live server at [meter.veritassuperaitsolutions.com](https://meter.veritassuperaitsolutions.com) accepts community submissions and visualizes aggregate data.
+The live server at [meter.vsits.co](https://meter.vsits.co) accepts community submissions and visualizes aggregate data.
 
 API endpoints:
 - `POST /api/v1/submit` — submit analysis summary (anonymous or API key)
@@ -179,7 +179,7 @@ Rate limits: 10 submissions/day anonymous, 100/day with API key.
 
 - [claude-code-cache-fix](https://github.com/cnighswonger/claude-code-cache-fix) — Prompt cache fix interceptor (108+ stars)
 - [claude-usage-dashboard](https://github.com/fgrosswig/claude-usage-dashboard) — Token forensics dashboard by @fgrosswig
-- [Blog series](https://veritassuperaitsolutions.com/three-layer-gate-quota-overage/) — Technical analysis of Claude Code's cache mechanics
+- [Blog series](https://vsits.co/three-layer-gate-quota-overage/) — Technical analysis of Claude Code's cache mechanics
 
 ## Support
 

--- a/SESSION_STATE.md
+++ b/SESSION_STATE.md
@@ -1,0 +1,59 @@
+# Session State — claude-code-meter
+
+Last updated: 2026-05-01T00:30Z
+
+## Current Status
+
+- **npm**: `claude-code-meter@0.1.0` published (pending republish under new domain — see Migration below)
+- **Server**: `vsits-meter-01` (143.198.28.42:3847), Node 20 + Caddy + systemd
+- **Dashboard**: `meter.vsits.co` (index.html + analysis.html). Pre-rebrand `meter.veritassuperaitsolutions.com` still serves the same backend via Caddy `:80 {}` catch-all + Cloudflare proxied DNS, so existing installs keep working until they upgrade.
+- **Daily cron**: 06:37 UTC, `analyze --share --yes`, logs to `~/.claude/meter-cron.log`
+- **Domain**: Cloudflare proxied; SSL Flexible per-hostname Configuration Rules (`(http.host eq "meter.vsits.co")` and equivalent for the legacy hostname). Zone-wide is Full for WordPress on both zones.
+
+## Migration to meter.vsits.co (2026-05-01)
+
+The corporate domain rebranded from veritassuperaitsolutions.com to vsits.co. Migration scope:
+
+- DNS A record `meter.vsits.co` → 143.198.28.42 in the vsits.co Cloudflare zone (proxied).
+- Cloudflare Configuration Rule overriding SSL/TLS mode to **Flexible** for `meter.vsits.co` (matches the existing rule on the old zone). **Gotcha**: matchers must use `http.host` field, not `http.request.full_uri` — the latter includes scheme + path so a wildcard pattern of just the hostname never fires. `(http.host eq "meter.vsits.co")` is the working form.
+- Code: `DEFAULT_SERVER`, consent scope, README links, and dashboard HTML company links all swapped to vsits.co. `package.json` author updated. Branch `feat/migrate-to-vsits-co`.
+- Caddy required NO changes — `:80 {}` catch-all already accepts every hostname.
+
+## Recent Fix
+
+- **2026-04-18**: Added `claude-opus-4-7` to `KNOWN_RATES` in `src/constants.mjs`. 4.7 was missing, causing `cost_analysis.by_model` to skip all 4.7 calls. Dashboard showed 4.7 as a model category but with zero cost data. Deployed to server, re-ran `analyze --share`. Now showing 1,332 4.7 calls at $131.43 API cost.
+
+## Architecture
+
+- **Interceptor** (`src/interceptor/`): Patches `globalThis.fetch` via `NODE_OPTIONS=--import`. Read-only — captures response headers + usage from SSE stream. Never accesses request bodies.
+- **CLI** (`bin/claude-meter.mjs`): status, history, rates (OLS regression), analyze, share
+- **Server** (`server/index.mjs`): Community API — accepts analysis submissions, serves dashboard data. Rate limited, anonymous + keyed auth.
+- **Dashboard** (`public/`): Highcharts-based. index.html (overview) + analysis.html (deep analysis with model breakdown, cost charts, capacity estimates).
+
+## Critical: Preload is dead on CC v2.1.113+
+
+The `--import` preload mechanism is killed by the Bun binary switch. Migration to proxy architecture tracked at `cnighswonger/claude-code-cache-fix#40` and `cnighswonger/claude-code-meter#2`. Meter capture logic moves into the proxy's response path.
+
+## Pending Tasks
+
+- **Dashboard auto-refresh**: Add setInterval on fetch calls (5-10 min). Chris requested 2026-04-13.
+- **Submission dedup**: Use `install_id` (per-install hash in `~/.claude/claude-meter-config.json`) server-side to distinguish unique contributors. Currently overstates contributor count.
+- **CLAUDE_METER_SHARE=1 background tier**: Auto-report on session exit. Deferred until Tier 2 (explicit `analyze --share`) is validated.
+- **NEXO exporter**: `claude-meter export --format nexo`. Low priority.
+- **npm re-publish**: v0.1.2 with dedup + any accumulated fixes.
+- **Proxy migration**: Move response-side capture into cache-fix proxy. Blocked by #40.
+
+## Data
+
+- Local JSONL: `~/.claude/claude-meter.jsonl` (~18K+ rows)
+- Server dataset: 1 submission (our own), 18K+ calls, 85 sessions
+- Models tracked: opus-4-6 (15,018), haiku-4-5 (1,855), opus-4-7 (1,332), sonnet-4-6 (9)
+- Model spoofing: none detected across 2,636 checked calls
+
+## Key Design Constraints
+
+- Interceptor NEVER reads request bodies (privacy guarantee)
+- `response.clone()` not TransformStream (TransformStream breaks CC's SSE)
+- Strict Zod schemas with `z.strictObject()` — no freeform text
+- Share payload aggregates to session level — per-turn granularity never leaves machine
+- Consent token required on first share (cryptographically bound to install_id)

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "type": "git",
     "url": "git+https://github.com/cnighswonger/claude-code-meter.git"
   },
-  "author": "Chris Nighswonger <chris@veritassuperaitsolutions.com> (https://veritassuperaitsolutions.com)",
+  "author": "Chris Nighswonger <dev@vsits.co> (https://vsits.co)",
   "keywords": [
     "claude",
     "claude-code",

--- a/public/analysis.html
+++ b/public/analysis.html
@@ -93,7 +93,7 @@
 <div id="content"><p style="color:#64748b">Loading analysis data...</p></div>
 
 <footer>
-  <a href="https://veritassuperaitsolutions.com">Veritas Supera IT Solutions LLC</a> |
+  <a href="https://vsits.co">Veritas Supera IT Solutions LLC</a> |
   <a href="https://github.com/cnighswonger/claude-code-meter">Source</a> |
   <a href="/">Dashboard</a> |
   <a href="https://buymeacoffee.com/vsits" title="Buy us a coffee"><img src="https://cdn.buymeacoffee.com/buttons/bmc-new-btn-logo.svg" alt="coffee" style="height:16px;vertical-align:middle;opacity:0.6"></a>
@@ -303,7 +303,7 @@ async function loadAnalysis() {
   html += `<tr><td>Cache hit rate (avg)</td><td class="ctr good">${avgCacheSavingsPct.toFixed(0)}%</td><td>Cache optimization is the primary value driver</td></tr>`;
   html += `<tr><td>Cost exponent (mean)</td><td class="ctr">${(primary.exponents?.mean || 0).toFixed(2)}</td><td>${(primary.exponents?.mean || 0) < 1.1 ? 'Approximately linear — cost per turn is stable' : 'Superlinear — cost per turn increases over session'}</td></tr>`;
   html += '</table>';
-  html += '<p style="color:#64748b;font-size:0.8rem;margin-top:12px">The "5x" multiplier is applied to an undefined base. See <a href="https://veritassuperaitsolutions.com/three-layer-gate-quota-overage/" style="color:#60a5fa">our analysis</a> for the full discussion of what the TOS and published documents say about this number.</p>';
+  html += '<p style="color:#64748b;font-size:0.8rem;margin-top:12px">The "5x" multiplier is applied to an undefined base. See <a href="https://vsits.co/three-layer-gate-quota-overage/" style="color:#60a5fa">our analysis</a> for the full discussion of what the TOS and published documents say about this number.</p>';
   html += '</div>';
 
   // Section 5: Cost per turn by model

--- a/public/index.html
+++ b/public/index.html
@@ -118,7 +118,7 @@
   Community cost analytics for Claude Code subscriptions.
   <a href="https://github.com/cnighswonger/claude-code-meter">GitHub</a> |
   <a href="https://github.com/cnighswonger/claude-code-cache-fix">Cache Fix</a> |
-  <a href="https://veritassuperaitsolutions.com">VSITS</a>
+  <a href="https://vsits.co">VSITS</a>
 </p>
 
 <div class="stats-row" id="stats-row"></div>
@@ -134,7 +134,7 @@
 </div>
 
 <footer>
-  <a href="https://veritassuperaitsolutions.com">Veritas Supera IT Solutions LLC</a> |
+  <a href="https://vsits.co">Veritas Supera IT Solutions LLC</a> |
   Data is anonymous, aggregate, and community-contributed.
   <a href="/api/v1/stats">API</a> |
   <a href="/api/v1/dataset">Raw dataset</a> |

--- a/src/consent.mjs
+++ b/src/consent.mjs
@@ -77,12 +77,21 @@ export function getInstallId() {
 }
 
 /**
+ * Consent scope.
+ *
+ * Bound to the corporate domain. Changing this string invalidates every
+ * stored consent token (token = SHA-256(install_id + timestamp + scope)),
+ * which forces re-consent. We're OK with that because the install base is
+ * still pre-public; a rebrand-driven re-prompt has no real-world impact.
+ */
+const CONSENT_SCOPE = "share_anonymous_usage_data_with_meter.vsits.co";
+
+/**
  * Generate a consent token from install_id + timestamp.
  * Token = SHA-256(install_id + consent_timestamp + consent_scope)
  */
 function generateConsentToken(installId, timestamp) {
-  const scope = "share_anonymous_usage_data_with_meter.veritassuperaitsolutions.com";
-  const input = `${installId}:${timestamp}:${scope}`;
+  const input = `${installId}:${timestamp}:${CONSENT_SCOPE}`;
   return createHash("sha256").update(input).digest("hex").slice(0, 32);
 }
 
@@ -96,7 +105,6 @@ export function getConsentStatus() {
     return { consented: false, reason: "opted_out" };
   }
   if (config.consent_token && config.consent_timestamp && config.install_hash) {
-    // Verify token is valid for this install
     const expected = generateConsentToken(config.install_hash, config.consent_timestamp);
     if (config.consent_token === expected) {
       return {

--- a/src/constants.mjs
+++ b/src/constants.mjs
@@ -51,8 +51,8 @@ export const KNOWN_RATES = {
   },
 };
 
-// Community API server
-export const DEFAULT_SERVER = "https://meter.veritassuperaitsolutions.com";
+// Community API server.
+export const DEFAULT_SERVER = "https://meter.vsits.co";
 
 // Rate-limit header names
 export const HEADERS = {


### PR DESCRIPTION
The corporate domain rebranded from veritassuperaitsolutions.com to vsits.co. Old domain only redirects now.

## What changed (client)

- `src/constants.mjs`: `DEFAULT_SERVER` → `https://meter.vsits.co`
- `src/consent.mjs`: scope string → `share_anonymous_usage_data_with_meter.vsits.co`. Pre-rebrand install base is just us, so legacy back-compat scaffolding removed; existing consents one-time re-prompt
- `package.json` author: `dev@vsits.co` + `https://vsits.co`
- `README.md`: 4 meter URL refs + corporate site link
- `public/index.html`, `public/analysis.html`: corporate "VSITS" / "Veritas Supera IT Solutions LLC" / blog-link refs
- `SESSION_STATE.md`: dashboard URL + migration narrative + CF expression-syntax gotcha (matchers must use `http.host`, not `http.request.full_uri` with hostname-only wildcard pattern)

## What changed (server, already deployed at the droplet)

- Cloudflare DNS A record `meter.vsits.co` → 143.198.28.42 (proxied)
- Wildcard `*.vsits.co` Let's Encrypt cert covers the new hostname
- Configuration Rule on vsits.co zone: `(http.host eq "meter.vsits.co")` → SSL Flexible
- Caddy needed NO changes (`:80 {}` catch-all already accepts every hostname)
- Dashboard files already deployed via `git fetch + checkout origin/feat/migrate-to-vsits-co -- public/` on the droplet; service restarted

## Backwards compatibility

`meter.veritassuperaitsolutions.com` continues to serve the same backend (dual-vhost via Caddy catch-all). Existing claude-code-meter installs continue working until they upgrade. The cron-driven daily share is just our own install on visits-01.

## Verification

- Both URLs serve identical HTML (dual-vhost confirmed)
- Cache-buster query against new URL returns 2 `vsits.co` refs in the footer
- `ingest-cli.test.mjs` passes; consent module loads cleanly
- Zero remaining `veritassuperaitsolutions.com` refs in code/data (only in `SESSION_STATE.md` migration narrative — intentional)

— AI Team Lead